### PR TITLE
zip error fixed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ vpk: release/$(TARGET).vpk
 eboot: release/eboot.bin
 	
 %.vpk: vpk/eboot.bin vpk/sce_sys/param.sfo
-	cd vpk; zip -r -q ../$@ ./*; cd ..
+	mkdir release;cd vpk; zip -r -q ../$@ ./*; cd ..
 
 release/eboot.bin: vpk/eboot.bin
 	cp vpk/eboot.bin release


### PR DESCRIPTION
release dir wasn't created

> cd vpk; zip -r -q ../release/vita-activator.vpk ./*; cd ..
> zip I/O error: Not a directory
> zip error: Could not create output file (../release/vita-activator.vpk)
> cp vpk/eboot.bin release
